### PR TITLE
Inclusion has domain, not axis

### DIFF
--- a/src/ContinuumArrays.jl
+++ b/src/ContinuumArrays.jl
@@ -31,7 +31,7 @@ cardinality(::AbstractInterval) = ℵ₁
 
 
 checkindex(::Type{Bool}, inds::AbstractInterval, i::Real) = (leftendpoint(inds) <= i) & (i <= rightendpoint(inds))
-checkindex(::Type{Bool}, inds::AbstractInterval, i::Inclusion) = i.axis ⊆ inds
+checkindex(::Type{Bool}, inds::AbstractInterval, i::Inclusion) = i.domain ⊆ inds
 function checkindex(::Type{Bool}, inds::AbstractInterval, I::AbstractArray)
     @_inline_meta
     b = true


### PR DESCRIPTION
Discovered when transitioning to `Applied`, before I saw that `axes(R,1)` should not be an `Inclusion`.