### PR TITLE
Fix show for intervals

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ import LazyArrays: MemoryLayout, ApplyStyle, Applied, colsupport, arguments, App
         @test D*x ≡ QuasiOnes(x)
         @test D^2 * x ≡ QuasiZeros(x)
         @test D*[x D*x] == [D*x D^2*x]
-        @test stringmime("text/plain", D) == "Derivative(Inclusion(-1..1))"
+        @test stringmime("text/plain", D) == "Derivative(Inclusion($(-1..1)))"
         @test_throws DimensionMismatch Derivative(Inclusion(0..1)) * x
     end
 end
@@ -65,9 +65,9 @@ include("test_maps.jl")
     @test δ[0.0] ≡ Inf
     @test Base.IndexStyle(δ) ≡ Base.IndexLinear()
 
-    @test stringmime("text/plain", δ) == "δ at 0.0 over Inclusion(-1..3)"
+    @test stringmime("text/plain", δ) == "δ at 0.0 over Inclusion($(-1..3))"
     x = Inclusion(-1..1)
-    @test stringmime("text/plain", δ[2x .+ 1]) == "δ at 0.0 over Inclusion(-1..3) affine mapped to -1..1"
+    @test stringmime("text/plain", δ[2x .+ 1]) == "δ at 0.0 over Inclusion($(-1..3)) affine mapped to $(-1..1)"
 end
 
 @testset "Kernels" begin

--- a/test/test_chebyshev.jl
+++ b/test/test_chebyshev.jl
@@ -110,8 +110,8 @@ Base.:(==)(::FooBasis, ::FooBasis) = true
     @testset "Mapped" begin
         y = affine(0..1, x)
 
-        @test summary(T[y,:]) == "Chebyshev affine mapped to 0..1"
-        @test stringmime("text/plain", T[y,:]) == "Chebyshev(5) affine mapped to 0..1"
+        @test summary(T[y,:]) == "Chebyshev affine mapped to $(0..1)"
+        @test stringmime("text/plain", T[y,:]) == "Chebyshev(5) affine mapped to $(0..1)"
         @test MemoryLayout(wT[y,:]) isa MappedWeightedBasisLayout
         @test MemoryLayout(w[y] .* T[y,:]) isa MappedWeightedBasisLayout
         @test wT[y,:][[0.1,0.2],1:5] == (w[y] .* T[y,:])[[0.1,0.2],1:5] == (w .* T[:,1:5])[y,:][[0.1,0.2],:]

--- a/test/test_maps.jl
+++ b/test/test_maps.jl
@@ -73,7 +73,7 @@ import ContinuumArrays: AffineQuasiVector
     end
 
     @testset "show" begin
-        @test stringmime("text/plain", y) == "2.0 * Inclusion(0..1) .+ (-1.0)"
-        @test stringmime("text/plain", a) == "Affine map from Inclusion(-2..3) to Inclusion(-1..1)"
+        @test stringmime("text/plain", y) == "2.0 * Inclusion($(0..1)) .+ (-1.0)"
+        @test stringmime("text/plain", a) == "Affine map from Inclusion($(-2..3)) to Inclusion($(-1..1))"
     end
 end

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -469,7 +469,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
         H = HeavisideSpline([1,2,3,6])
         B = H[5x .+ 1,:]
         u = H * [1,2,3]
-        @test stringmime("text/plain", B) == "HeavisideSpline([1, 2, 3, 6]) affine mapped to 0..1"
+        @test stringmime("text/plain", B) == "HeavisideSpline([1, 2, 3, 6]) affine mapped to $(0..1)"
     end
 
     @testset "A \\ ( c .* B) == c .* (A\\B) #101" begin


### PR DESCRIPTION
`IntervalSets` v0.7.5 now prints intervals with spaces, which broke some of the display tests here. This PR fixes these by interpolating the intervals into the string.