### PR TITLE
Refine tensor transform interface

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,26 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master # update to match your development branch (master, main, dev, trunk, ...)
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.9'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ContinuumArrays"
 uuid = "7ae1f121-cc2c-504b-ac30-9b923412ae5c"
-version = "0.16.4"
+version = "0.17"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A package for representing quasi arrays with continuous dimensions
 
 [![Build Status](https://github.com/JuliaApproximation/ContinuumArrays.jl/workflows/CI/badge.svg)](https://github.com/JuliaApproximation/ContinuumArrays.jl/actions)
 [![codecov](https://codecov.io/gh/JuliaApproximation/ContinuumArrays.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaApproximation/ContinuumArrays.jl)
+[![docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaApproximation.github.io/ContinuumArrays.jl/dev)
 
 
 A quasi array as implemented in [QuasiArrays.jl](https://github.com/JuliaApproximation/QuasiArrays.jl) is a 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,12 @@
+using Documenter, ContinuumArrays
+
+makedocs(
+    modules = [ContinuumArrays],
+    sitename="ContinuumArrays.jl",
+    pages = Any[
+        "Home" => "index.md"])
+
+deploydocs(
+    repo = "github.com/JuliaApproximation/ContinuumArrays.jl.git",
+    push_preview = true
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,3 +8,12 @@ To add your own bases, subtype `Basis` and overload the following routines:
 1. `axes(::MyBasis) = (Inclusion(mydomain), OneTo(mylength))`
 2. `grid(::MyBasis, ::Integer)`
 3. `getindex(::MyBasis, x, ::Integer)`
+4. `==(::MyBasis, ::MyBasis)`
+
+Optional overloads are:
+
+1. `plan_transform(::MyBasis, sizes::NTuple{N,Int}, region)` to plan a transform, for a tensor
+product of the specified sizes, similar to `plan_fft`.
+2. `diff(::MyBasis, dims=1)` to support differentiation and `Derivative`. 
+3. `grammatrix(::MyBasis)` to support `Q'Q`. 
+4. `ContinuumArrays._sum(::MyBasis, dims)` and `ContinuumArrays._cumsum(::MyBasis, dims)` to support definite and indefinite integeration.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,3 +17,59 @@ product of the specified sizes, similar to `plan_fft`.
 2. `diff(::MyBasis, dims=1)` to support differentiation and `Derivative`. 
 3. `grammatrix(::MyBasis)` to support `Q'Q`. 
 4. `ContinuumArrays._sum(::MyBasis, dims)` and `ContinuumArrays._cumsum(::MyBasis, dims)` to support definite and indefinite integeration.
+
+
+## Routines
+
+
+```@docs
+Derivative
+```
+```@docs
+transform
+```
+```@docs
+expand
+```
+```@docs
+grid
+```
+
+
+## Interal Routines
+
+```@docs
+ContinuumArrays.TransformFactorization
+```
+
+```@docs
+ContinuumArrays.AbstractConcatBasis
+```
+```@docs
+ContinuumArrays.MulPlan
+```
+```@docs
+ContinuumArrays.PiecewiseBasis
+```
+```@docs
+ContinuumArrays.MappedFactorization
+```
+```@docs
+ContinuumArrays.basis :: Tuple{Any}
+```
+```@docs
+ContinuumArrays.InvPlan
+```
+```@docs
+ContinuumArrays.VcatBasis
+```
+```@docs
+ContinuumArrays.WeightedFactorization
+```
+```@docs
+ContinuumArrays.HvcatBasis
+```
+```@docs
+ContinuumArrays.ProjectionFactorization
+```
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,10 @@
+# ContinuumArrays.jl
+A Julia package for working with bases as quasi-arrays
+
+## The Basis interface
+
+To add your own bases, subtype `Basis` and overload the following routines:
+
+1. `axes(::MyBasis) = (Inclusion(mydomain), OneTo(mylength))`
+2. `grid(::MyBasis, ::Integer)`
+3. `getindex(::MyBasis, x, ::Integer)`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,7 +55,7 @@ ContinuumArrays.PiecewiseBasis
 ContinuumArrays.MappedFactorization
 ```
 ```@docs
-ContinuumArrays.basis :: Tuple{Any}
+ContinuumArrays.basis
 ```
 ```@docs
 ContinuumArrays.InvPlan

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -191,6 +191,12 @@ function plan_grid_transform_layout(lay, L, szs::NTuple{N,Int}, dims=ntuple(iden
     ps, InvPlan(map(p -> factorize(L[p,:]), ps), dims)
 end
 
+function plan_grid_transform_layout(lay, L, szs::NTuple{N,Int}, d::Int) where N
+    p = grid(L, szs[d])
+    p, InvPlan(factorize(L[p,:]), d)
+end
+
+
 
 function plan_grid_transform_layout(::MappedBasisLayout, L, szs::NTuple{N,Int}, dims=ntuple(identity,Val(N))) where N
     x,F = plan_grid_transform(demap(L), szs, dims)

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -180,7 +180,9 @@ grid(L, B::Block) = grid(L, Block.(B.n)) # grid(L, Block(2,3)) == grid(L, (Block
 grid(L, ns::Tuple) = grid.(Ref(L), ns)
 grid(L) = grid(L, size(L,2))
 
-grid_layout(_, P, n) = error("Overload grid(::$(typeof(P)), ::Integer)")
+grid_layout(_, P, n) = grid_axis(axes(P,2), P, n)
+
+grid_axis(::OneTo, P, n::Block) = grid(P, size(P,2))
 
 grid_layout(::MappedBasisLayout, P, n) = invmap(parentindices(P)[1])[grid(demap(P), n)]
 grid_layout(::SubBasisLayout, P::AbstractQuasiMatrix, n) = grid(parent(P), parentindices(P)[2][n])
@@ -204,6 +206,7 @@ plan_transform(L, szs::NTuple{N,Int}, dims=ntuple(identity,Val(N))) where N = pl
 
 plan_transform(L, arr::AbstractArray, dims...) = plan_transform(L, size(arr), dims...)
 plan_transform(L, lng::Union{Integer,Block{1}}, dims...) = plan_transform(L, (lng,), dims...)
+plan_transform(L) = plan_transform(L, size(L,2))
     
 
 

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -193,7 +193,7 @@ grid_layout(::WeightedBasisLayouts, P, n) = grid(unweighted(P), n)
 # note this computes the grid an extra time.
 
 blockoroneto(n::Int) = OneTo(n)
-blockoroneto(n::Block{1}) = Block.(OneTo(n))
+blockoroneto(n::Block{1}) = Block.(OneTo(Int(n)))
 function plan_transform_layout(lay, L, szs::NTuple{N,Union{Int,Block{1}}}, dims=ntuple(identity,Val(N))) where N
     dimsz = getindex.(Ref(szs), dims) # get the sizes of transformed dimensions
     InvPlan(map(n -> factorize(L[grid(L,n),blockoroneto(n)]), dimsz), dims)

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -192,11 +192,14 @@ grid_layout(::WeightedBasisLayouts, P, n) = grid(unweighted(P), n)
 # Default transform is just solve least squares on a grid
 # note this computes the grid twice.
 function plan_transform_layout(lay, L, szs::NTuple{N,Int}, dims=ntuple(identity,Val(N))) where N
-    ps = grid(L, getindex.(Ref(szs), dims))
     if dims isa Integer
-        InvPlan(factorize(L[ps,:]), dims)
+        n = szs[dims]
+        p = grid(L, n)
+        InvPlan(factorize(L[p,OneTo(n)]), dims)
     else
-        InvPlan(map(p -> factorize(L[p,:]), ps), dims)
+        dimsz = getindex.(Ref(szs), dims)
+        ps = grid(L, dimsz)
+        InvPlan(map((p,n) -> factorize(L[p,OneTo(n)]), ps, dimsz), dims)
     end
 end
 

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -204,6 +204,8 @@ plan_transform(L, szs::NTuple{N,Union{Int,Block{1}}}, dims=ntuple(identity,Val(N
 plan_transform(L, arr::AbstractArray, dims...) = plan_transform(L, size(arr), dims...)
 plan_transform(L, lng::Union{Integer,Block{1}}, dims...) = plan_transform(L, (lng,), dims...)
 plan_transform(L) = plan_transform(L, size(L,2))
+
+plan_transform(L, B::Block, dims...) = plan_transform(L, Block.(B.n), dims...) # grid(L, Block(2,3)) == grid(L, (Block(2), Block(3))
     
 
 

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -191,9 +191,6 @@ grid_layout(::WeightedBasisLayouts, P, n) = grid(unweighted(P), n)
 
 # Default transform is just solve least squares on a grid
 # note this computes the grid an extra time.
-
-blockoroneto(n::Block{1}) = Block.(OneTo(Int(n)))
-
 mapfactorize(L, n::Integer) = factorize(L[grid(L,n),OneTo(n)])
 mapfactorize(L, n::Block{1}) = factorize(L[grid(L,n),Block.(OneTo(Int(n)))])
 

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -192,7 +192,7 @@ grid_layout(::WeightedBasisLayouts, P, n) = grid(unweighted(P), n)
 function plan_transform_layout(lay, L, szs::NTuple{N,Int}, dims=ntuple(identity,Val(N))) where N
     ps = grid(L, getindex.(Ref(szs), dims))
     if dims isa Integer
-        InvPlan(factorize(L[p,:]), d)
+        InvPlan(factorize(L[ps,:]), dims)
     else
         InvPlan(map(p -> factorize(L[p,:]), ps), dims)
     end

--- a/src/bases/splines.jl
+++ b/src/bases/splines.jl
@@ -47,8 +47,9 @@ function getindex(B::HeavisideSpline{T}, x::Number, k::Int) where T
     return zero(T)
 end
 
-grid(L::HeavisideSpline, ::NTuple{N,Any}) where N = ntuple(_ -> L.points[1:end-1] .+ diff(L.points)/2, Val(N))
-grid(L::LinearSpline, ::NTuple{N,Any}) where N = ntuple(_ -> L.points, Val(N))
+# Splines sample same number of points regardless of length.
+grid(L::HeavisideSpline, ::Integer) = L.points[1:end-1] .+ diff(L.points)/2
+grid(L::LinearSpline, ::Integer) = L.points
 
 ## Sub-bases
 

--- a/src/bases/splines.jl
+++ b/src/bases/splines.jl
@@ -47,8 +47,8 @@ function getindex(B::HeavisideSpline{T}, x::Number, k::Int) where T
     return zero(T)
 end
 
-grid(L::HeavisideSpline, n...) = L.points[1:end-1] .+ diff(L.points)/2
-grid(L::LinearSpline, n...) = L.points
+grid(L::HeavisideSpline, ::NTuple{N,Any}) where N = ntuple(_ -> L.points[1:end-1] .+ diff(L.points)/2, Val(N))
+grid(L::LinearSpline, ::NTuple{N,Any}) where N = ntuple(_ -> L.points, Val(N))
 
 ## Sub-bases
 

--- a/src/plans.jl
+++ b/src/plans.jl
@@ -39,19 +39,20 @@ end
 InvPlan(fact, dims) = InvPlan{eltype(fact), typeof(fact), typeof(dims)}(fact, dims)
 
 size(F::InvPlan) = size.(F.factorizations, 1)
+size(F::InvPlan{<:Any,<:Any,Int}) = size(F.factorizations, 1)
 
 
 function *(P::InvPlan{<:Any,<:Any,Int}, x::AbstractVector)
     @assert P.dims == 1
-    only(P.factorizations) \ x
+    P.factorizations \ x
 end
 
 function *(P::InvPlan{<:Any,<:Any,Int}, X::AbstractMatrix)
     if P.dims == 1
-        P.factorizations[P.dims] \ X
+        P.factorizations \ X
     else
         @assert P.dims == 2
-        permutedims(P.factorizations[P.dims] \ permutedims(X))
+        permutedims(P.factorizations \ permutedims(X))
     end
 end
 
@@ -59,16 +60,16 @@ function *(P::InvPlan{<:Any,<:Any,Int}, X::AbstractArray{<:Any,3})
     Y = similar(X)
     if P.dims == 1
         for j in axes(X,3)
-            Y[:,:,j] = P.factorizations[P.dims] \ X[:,:,j]
+            Y[:,:,j] = P.factorizations \ X[:,:,j]
         end
     elseif P.dims == 2
         for k in axes(X,1)
-            Y[k,:,:] = P.factorizations[P.dims] \ X[k,:,:]
+            Y[k,:,:] = P.factorizations \ X[k,:,:]
         end
     else
         @assert P.dims == 3
         for k in axes(X,1), j in axes(X,2)
-            Y[k,j,:] = P.factorizations[P.dims] \ X[k,j,:]
+            Y[k,j,:] = P.factorizations \ X[k,j,:]
         end
     end
     Y
@@ -76,7 +77,7 @@ end
 
 function *(P::InvPlan, X::AbstractArray)
     for d in P.dims
-        X = InvPlan(P.factorizations, d) * X
+        X = InvPlan(P.factorizations[d], d) * X
     end
     X
 end

--- a/src/plans.jl
+++ b/src/plans.jl
@@ -44,12 +44,12 @@ size(F::InvPlan{<:Any,<:Any,Int}) = size(F.factorizations, 1)
 
 function *(P::InvPlan{<:Any,<:Any,Int}, x::AbstractVector)
     @assert P.dims == 1
-    P.factorizations \ x
+    P.factorizations \ x # Only a single factorization when dims isa Int
 end
 
 function *(P::InvPlan{<:Any,<:Any,Int}, X::AbstractMatrix)
     if P.dims == 1
-        P.factorizations \ X
+        P.factorizations \ X  # Only a single factorization when dims isa Int
     else
         @assert P.dims == 2
         permutedims(P.factorizations \ permutedims(X))
@@ -97,7 +97,7 @@ MulPlan(mats, dims) = MulPlan{eltype(mats), typeof(mats), typeof(dims)}(mats, di
 
 function *(P::MulPlan{<:Any,<:Any,Int}, x::AbstractVector)
     @assert P.dims == 1
-    only(P.matrices) * x
+    P.matrices * x
 end
 
 function *(P::MulPlan{<:Any,<:Any,Int}, X::AbstractMatrix)

--- a/src/plans.jl
+++ b/src/plans.jl
@@ -102,10 +102,10 @@ end
 
 function *(P::MulPlan{<:Any,<:Any,Int}, X::AbstractMatrix)
     if P.dims == 1
-        P.matrices[P.dims] * X
+        P.matrices * X
     else
         @assert P.dims == 2
-        permutedims(P.matrices[P.dims] * permutedims(X))
+        permutedims(P.matrices * permutedims(X))
     end
 end
 
@@ -113,16 +113,16 @@ function *(P::MulPlan{<:Any,<:Any,Int}, X::AbstractArray{<:Any,3})
     Y = similar(X)
     if P.dims == 1
         for j in axes(X,3)
-            Y[:,:,j] = P.matrices[P.dims] * X[:,:,j]
+            Y[:,:,j] = P.matrices * X[:,:,j]
         end
     elseif P.dims == 2
         for k in axes(X,1)
-            Y[k,:,:] = P.matrices[P.dims] * X[k,:,:]
+            Y[k,:,:] = P.matrices * X[k,:,:]
         end
     else
         @assert P.dims == 3
         for k in axes(X,1), j in axes(X,2)
-            Y[k,j,:] = P.matrices[P.dims] * X[k,j,:]
+            Y[k,j,:] = P.matrices * X[k,j,:]
         end
     end
     Y
@@ -130,7 +130,7 @@ end
 
 function *(P::MulPlan, X::AbstractArray)
     for d in P.dims
-        X = MulPlan(P.matrices, d) * X
+        X = MulPlan(P.matrices[d], d) * X
     end
     X
 end

--- a/test/test_chebyshev.jl
+++ b/test/test_chebyshev.jl
@@ -17,7 +17,7 @@ struct ChebyshevWeight <: Weight{Float64} end
 Base.:(==)(::Chebyshev, ::Chebyshev) = true
 Base.:(==)(::ChebyshevWeight, ::ChebyshevWeight) = true
 Base.axes(T::Chebyshev) = (Inclusion(-1..1), Base.OneTo(T.n))
-ContinuumArrays.grid(T::Chebyshev, n...) = chebyshevpoints(Float64, T.n, Val(1))
+ContinuumArrays.grid(T::Chebyshev, ::Integer) = chebyshevpoints(Float64, T.n, Val(1))
 Base.axes(T::ChebyshevWeight) = (Inclusion(-1..1),)
 
 Base.getindex(::Chebyshev, x::Float64, n::Int) = cos((n-1)*acos(x))

--- a/test/test_chebyshev.jl
+++ b/test/test_chebyshev.jl
@@ -24,7 +24,7 @@ Base.getindex(::Chebyshev, x::Float64, n::Int) = cos((n-1)*acos(x))
 Base.getindex(::ChebyshevWeight, x::Float64) = 1/sqrt(1-x^2)
 Base.getindex(w::ChebyshevWeight, ::Inclusion) = w # TODO: make automatic
 
-ContinuumArrays.plan_grid_transform(L::Chebyshev, szs::NTuple{N,Int}, dims=1:N) where N = grid(L), plan_chebyshevtransform(Array{eltype(L)}(undef, szs...), dims)
+ContinuumArrays.plan_transform(L::Chebyshev, szs::NTuple{N,Int}, dims=1:N) where N = plan_chebyshevtransform(Array{eltype(L)}(undef, szs...), dims)
 ContinuumArrays.basis_axes(::Inclusion{<:Any,<:AbstractInterval}, v) = Chebyshev(100)
 function ContinuumArrays._sum(T::Chebyshev, dims)
     n = 2:size(T,2)-1

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -1,4 +1,4 @@
-using ContinuumArrays, LinearAlgebra, Base64, FillArrays, QuasiArrays, BandedMatrices, Test
+using ContinuumArrays, LinearAlgebra, Base64, FillArrays, QuasiArrays, BandedMatrices, BlockArrays, Test
 using QuasiArrays: ApplyQuasiArray, ApplyStyle, MemoryLayout, mul, MulQuasiMatrix, Vec
 import LazyArrays: MulStyle, LdivStyle, arguments, applied, apply
 import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout, SubBasisLayout, AdjointMappedBasisLayouts, MappedBasisLayout, plan_grid_transform, weaklaplacian
@@ -532,5 +532,33 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
         L = LinearSpline(0:5)
         u = ApplyQuasiArray(*, L, randn(6,5), randn(5))
         @test coefficients(u) ≈ L \ u
+    end
+
+    @testset "Block grid" begin
+        L = LinearSpline(0:5)
+        @test grid(L, Block(1)) == grid(L)
+    end
+
+    @testset "transform tests" begin
+        L = LinearSpline(0:5)
+        @testset "scalar"  begin
+            Pl = plan_transform(L)
+            @test size(Pl) == (6,)
+
+            x = randn(6)
+            @test inv(Pl)  * (Pl * x) ≈ x
+
+            A = randn(6,6)
+
+            P = A * inv(Pl)
+            @test P * x ≈ A * (Pl * x)
+        end
+
+        @testset "tensor" begin
+            Pl = plan_transform(L, (2,3))
+            @test size(Pl) == (6,6)
+            X = randn(6,6)
+            @test inv(Pl)  * (Pl * X) ≈ X
+        end
     end
 end

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -37,7 +37,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
         @test f[2.1] ≈ 2
 
         @test @inferred(H'H) == @inferred(materialize(applied(*,H',H))) == Eye(2)
-        @test summary(f) == stringmime("text/plain", f) == "HeavisideSpline([1, 2, 3]) * [1, 2]" 
+        @test summary(f) == stringmime("text/plain", f) == "HeavisideSpline([1, 2, 3]) * [1, 2]"
 
         @testset "sum/cumsum" begin
             H = HeavisideSpline(range(0,1;length=1000));
@@ -220,7 +220,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
             @test M == M
             @test M == M̃
             @test M̃ == M
-            
+
             @test (x .* M)[0.25,:] ≈ (x .* M̃)[0.25,:] ≈ 0.25 * M[0.25,:]
             @test (exp.(x) .* M)[0.25,:] ≈ exp(0.25) * M[0.25,:]
 
@@ -564,6 +564,9 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
             X = randn(6,6)
             @test inv(Pl)  * (Pl * X) ≈ X
             @test plan_transform(L, Block(1,1)) * X ≈ Pl*X
+
+            (x,y),Pl = plan_grid_transform(L, Block(1,1))
+            @test Pl*(exp.(x .+ y')) ≈ plan_transform(L, Block(1,1), 2) * (plan_transform(L, Block(1,1), 1) * exp.(x .+ y'))
         end
     end
 end

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -550,6 +550,8 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
             @test inv(Pl)  * (Pl * x) ≈ x
             @test inv(inv(Pl))*x ≈ Pl*x
 
+            @test plan_transform(L, Block(1))*x == Pl*x
+
             A = randn(6,6)
 
             P = A * inv(Pl)

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -537,6 +537,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
     @testset "Block grid" begin
         L = LinearSpline(0:5)
         @test grid(L, Block(1)) == grid(L)
+        @test grid(L, Block(1,1)) == grid(L, (6,6))
     end
 
     @testset "transform tests" begin
@@ -547,6 +548,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
 
             x = randn(6)
             @test inv(Pl)  * (Pl * x) ≈ x
+            @test inv(inv(Pl)) == Pl
 
             A = randn(6,6)
 

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -448,12 +448,12 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
             @test L[y,:][g,:] * (P * X) ≈ X
             @test P \ (P * X) ≈ P * (P \ X) ≈ X
 
-            (s,t),P = plan_grid_transform(L[y,:], (10,11))
+            (s,t),P = plan_grid_transform(L[y,:], (10,10))
             X = cos.(s .* sin.(t'))
             @test L[y,:][s,:]*(P * X)*L[y,:][t,:]' ≈ X
             @test P \ (P * X) ≈ P * (P \ X) ≈ X
 
-            (s,t,v),P = plan_grid_transform(L[y,:], (10,11,12))
+            (s,t,v),P = plan_grid_transform(L[y,:], (10,10,10))
             X = cos.(s .* sin.(t') .+ exp.(reshape(v,1,1,:)))
             @test P \ (P * X) ≈ P * (P \ X) ≈ X
         end

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -563,6 +563,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
             @test size(Pl) == (6,6)
             X = randn(6,6)
             @test inv(Pl)  * (Pl * X) ≈ X
+            @test plan_transform(L, Block(1,1)) * X ≈ Pl*X
         end
     end
 end

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -448,13 +448,13 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
             @test L[y,:][g,:] * (P * X) ≈ X
             @test P \ (P * X) ≈ P * (P \ X) ≈ X
 
-            g,P = plan_grid_transform(L[y,:], (10,10))
-            X = cos.(g .+ g')
-            @test L[y,:][g,:]*(P * X)*L[y,:][g,:]' ≈ X
+            (s,t),P = plan_grid_transform(L[y,:], (10,11))
+            X = cos.(s .* sin.(t'))
+            @test L[y,:][s,:]*(P * X)*L[y,:][t,:]' ≈ X
             @test P \ (P * X) ≈ P * (P \ X) ≈ X
 
-            g,P = plan_grid_transform(L[y,:], (10,10,10))
-            X = randn(10,10,10)
+            (s,t,v),P = plan_grid_transform(L[y,:], (10,11,12))
+            X = cos.(s .* sin.(t') .+ exp.(reshape(v,1,1,:)))
             @test P \ (P * X) ≈ P * (P \ X) ≈ X
         end
 

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -548,7 +548,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
 
             x = randn(6)
             @test inv(Pl)  * (Pl * x) ≈ x
-            @test inv(inv(Pl)) == Pl
+            @test inv(inv(Pl))*x ≈ Pl*x
 
             A = randn(6,6)
 
@@ -557,7 +557,7 @@ import ContinuumArrays: basis, AdjointBasisLayout, ExpansionLayout, BasisLayout,
         end
 
         @testset "tensor" begin
-            Pl = plan_transform(L, (2,3))
+            Pl = plan_transform(L, (6,6))
             @test size(Pl) == (6,6)
             X = randn(6,6)
             @test inv(Pl)  * (Pl * X) ≈ X


### PR DESCRIPTION
This refines the tensor transform interface. In particular:

1. `grid(P)` and `grid(P,n::Int)` return just a vector of points
2. `grid(P, (n,))`, `grid(P, (m,n))` etc. return a tuple of vectors of points in each dimension.
3. Similar for `plan_grid_transform`.


Thus one can do a 1D transform that gets out at least 5 coefficients via eg:
```julia
x = grid(P, 5)
P = plan_transform(P, 5)
P * f.(x)
```
or a 2D transform
```julia
x,y = grid(P, (5,6))
P = plan_transform(P, (5,6))
P * f.(x, y')
```

Note the "1D" and "2D" don't necessarily mean dimension of the geometry, eg, when combined with MultivariateOrthogonalPolynomials.jl the interface of a tensor product of disks would be:
```julia
Z = Zernike()
x,y = grid(Z, (Block(5),Block(6)))
P = plan_transform(Z, (Block(5),Block(6)))
P * f.(x, y')
```

@TSGut  this might be of use for you.