### PR TITLE
Fix docstring in `plotgrid`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ContinuumArrays"
 uuid = "7ae1f121-cc2c-504b-ac30-9b923412ae5c"
-version = "0.18.4"
+version = "0.18.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -9,7 +9,6 @@ returns a grid of points suitable for plotting. This may include
 endpoints or singular points not included in `grid`. `n` specifies
 the number of coefficients.
 """
-
 plotgrid(P, n...) = plotgrid_layout(MemoryLayout(P), P, n...)
 
 plotgrid_layout(lay, P, n...) = plotgrid_size(size(P), P, n...)


### PR DESCRIPTION
The newline meant `?plotgrid` didn't show the docstring