### PR TITLE
Fix missing docstring for `Map`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,6 +56,9 @@ ContinuumArrays.MulPlan
 ContinuumArrays.PiecewiseBasis
 ```
 ```@docs
+ContinuumArrays.Map
+```
+```@docs
 ContinuumArrays.MappedFactorization
 ```
 ```@docs

--- a/src/maps.jl
+++ b/src/maps.jl
@@ -10,7 +10,6 @@ is `union(m)`.
 Maps must also overload `invmap` to give the inverse of the map, which
 is equivalent to `invmap(m)[x] == findfirst(isequal(x), m)`.
 """
-
 abstract type Map{T} <: AbstractQuasiVector{T} end
 
 invmap(M::Map) = error("Overload invmap(::$(typeof(M)))")


### PR DESCRIPTION
New line prevented the docstring from showing in `?Map`